### PR TITLE
Improve auth panel UX

### DIFF
--- a/public/firebase.js
+++ b/public/firebase.js
@@ -53,6 +53,8 @@ const googleLoginBtn = document.getElementById("googleLoginBtn");
 const logoutBtn = document.getElementById("logoutBtn");
 const welcomeSpan = document.getElementById("welcome");
 
+let signUpMode = false;
+
 // ─────────────────────────────
 // 🧠 User State
 // ─────────────────────────────
@@ -75,6 +77,8 @@ onAuthStateChanged(auth, async (user) => {
     signUpBtn.style.display = "none";
     signInBtn.style.display = "none";
     googleLoginBtn.style.display = "none";
+    signUpMode = false;
+    signUpBtn.textContent = "Sign Up";
 
     const userRef = doc(db, "users", user.uid);
     const userSnap = await getDoc(userRef);
@@ -118,6 +122,8 @@ onAuthStateChanged(auth, async (user) => {
     signUpBtn.style.display = "inline-block";
     signInBtn.style.display = "inline-block";
     googleLoginBtn.style.display = "inline-block";
+    signUpMode = false;
+    signUpBtn.textContent = "Sign Up";
 
     window.firebaseGame = null;
   }
@@ -126,7 +132,14 @@ onAuthStateChanged(auth, async (user) => {
 // ─────────────────────────────
 // 🔐 Auth Actions
 // ─────────────────────────────
-window.signUp = async () => {
+window.startSignUp = async () => {
+  if (!signUpMode) {
+    signUpMode = true;
+    signInBtn.style.display = "none";
+    googleLoginBtn.style.display = "none";
+    signUpBtn.textContent = "Create Account";
+    return;
+  }
   try {
     const email = emailInput.value.trim();
     const pass = passwordInput.value.trim();

--- a/public/index.html
+++ b/public/index.html
@@ -95,17 +95,19 @@
       /* ─── AUTH PANEL: pinned to top-right ─── */
       #authBox {
         position: absolute;
-        top: 1rem;
-        right: 1rem;
+        top: 0.5rem;
+        right: 0.5rem;
         background: rgba(255, 255, 255, 0.95);
-        padding: 0.5rem 0.8rem;
+        padding: 0.4rem 0.6rem;
         border: 1px solid #ccc;
         border-radius: 6px;
+        max-width: 220px;
       }
       #authBox input,
       #authBox button {
-        display: inline-block;
-        margin: 0.2rem 0.2rem 0.2rem 0;
+        display: block;
+        margin: 0.2rem 0;
+        width: 100%;
       }
       #authBox button {
         background: #2e7d32;
@@ -139,7 +141,7 @@
     <div id="authBox">
       <input type="email" id="email" placeholder="Email" />
       <input type="password" id="password" placeholder="Password" />
-      <button id="signUpBtn" onclick="signUp()">Sign Up</button>
+      <button id="signUpBtn" onclick="startSignUp()">Sign Up</button>
       <button id="signInBtn" onclick="signIn()">Log In</button>
       <button id="googleLoginBtn" onclick="googleLogin()">Sign in with Google</button>
       <button onclick="logout()" id="logoutBtn" style="display:none;">


### PR DESCRIPTION
## Summary
- style auth box to be smaller and stack items vertically
- reset auth box state when login status changes
- add sign-up flow that hides other buttons on first click

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6ef34748323b121082fec4889c4